### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://openjdk.java.net/projects/jdk/18/"><img src="https://img.shields.io/badge/java-18-blue.svg"></a>
+  <a href="https://openjdk.java.net/projects/jdk/19/"><img src="https://img.shields.io/badge/java-19-blue.svg"></a>
 <a href="https://github.com/openucx/ucx/tree/v1.11.2"><img src="https://img.shields.io/badge/ucx-1.11.2-red.svg"></a>
   <a href="https://github.com/hhu-bsinfo/infinileap/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-orange.svg"></a>
   
@@ -115,7 +115,7 @@ This demo atomically increments a value residing inside the remote server's memo
   - If your JDK is not installed in one of the default locations, Gradle can be instructed to look in a custom location. To enable this feature the `org.gradle.java.installations.paths` property has to be set within your global `gradle.properties` file usually located inside `${HOME}/.gradle`.
     
     ```
-    org.gradle.java.installations.paths=/custom/path/jdk18
+    org.gradle.java.installations.paths=/custom/path/jdk19
     ```
     
   - The HotSpot VM uses the SIGSEGV signal for its own purposes, which may interfere with signal handlers installed by the ucx library. Fortunately, ucx's signal handlers can be disabled by using an undocumented environment variable (see [MPI.jl issue #337](https://github.com/JuliaParallel/MPI.jl/issues/337#issuecomment-578377458)).
@@ -135,7 +135,7 @@ This demo atomically increments a value residing inside the remote server's memo
 
 ## :wrench: &nbsp; Requirements
 
-  * [OpenJDK 18 + Project Panama](https://github.com/openjdk/panama-foreign/tree/foreign-jextract)
+  * [OpenJDK 19 + Project Panama](https://github.com/openjdk/panama-foreign/tree/foreign-jextract)
       
     > We provide nightly builds of the `foreign-jextract` branch, which are compatible with [SDKMAN!](https://sdkman.io).
     > 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ ext {
     protobufVersion = '3.15.8'
 
     // Logging
-    slf4jVersion = '1.7.30'
+    slf4jVersion = '1.7.32'
     log4jVersion = '2.14.1'
 
     // Benchmarking
@@ -18,11 +18,11 @@ ext {
     // Code Generation
     lombokVersion = '1.18.20'
     tomcatAnnotationsVersion = '6.0.53'
-    jetbrainsAnnotationsVersion = '20.1.0'
+    jetbrainsAnnotationsVersion = '22.0.0'
 
     // Testing
-    junitJupiterVersion = '5.7.1'
-    assertjVersion = '3.19.0'
+    junitJupiterVersion = '5.8.2'
+    assertjVersion = '3.21.0'
 }
 
 buildscript {
@@ -38,5 +38,5 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = "7.2"
+    gradleVersion = "7.3.1"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(18))
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }
 

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Context.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Context.java
@@ -138,7 +138,7 @@ public class Context extends NativeObject implements AutoCloseable {
             }
 
 
-            var remoteKey = MemorySegment.ofAddressNative(
+            var remoteKey = MemorySegment.ofAddress(
                     pointer.get(ValueLayout.ADDRESS, 0L),
                     size.get(ValueLayout.JAVA_LONG, 0L),
                     ResourceScope.globalScope()

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/util/MemoryUtil.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/util/MemoryUtil.java
@@ -16,7 +16,7 @@ public class MemoryUtil {
 
 
     public static MemorySegment wrap(MemoryAddress address, long capacity) {
-        return MemorySegment.ofAddressNative(address, capacity, ResourceScope.globalScope());
+        return MemorySegment.ofAddress(address, capacity, ResourceScope.globalScope());
     }
 
     public static MemorySegment allocate(MemoryLayout layout) {

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/util/NativeError.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/util/NativeError.java
@@ -7,7 +7,7 @@ import static org.unix.Linux.*;
 
 public class NativeError {
 
-    private static final MemorySegment ERRNO = MemorySegment.ofAddressNative(
+    private static final MemorySegment ERRNO = MemorySegment.ofAddress(
             __errno_location(), ValueLayout.ADDRESS.byteSize(), ResourceScope.globalScope());
 
     public static final int OK = 0;

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(18))
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(18))
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR does some housekeeping and brings `infinileap` up-to-date with the latest changes in Project Panama:

- Update dependencies of the `core` module
- Update Gradle to 7.3.1
- Migrate to Java 19, on which the latest Panama builds are based
- Adapt to a change in the Foreign MemoryAPI (`MemorySegment.ofAddressNative()` has been renamed to `MemorySegment.ofAddress()`)