### PR TITLE
Publish artifacts in the GitHub Package Registry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 os: linux
 dist: focal
 language: java
+jdk:
+  - openjdk17
 
 addons:
   apt:
@@ -13,6 +15,8 @@ addons:
 
 stages:
   - name: build
+  - name: release
+    if: tag IS present
 
 jobs:
   include:
@@ -21,7 +25,29 @@ jobs:
         - wget -O panama.zip https://coconucos.cs.hhu.de/forschung/jdk/latest.zip
         - unzip panama.zip -d /tmp
         - echo "org.gradle.java.installations.paths=/tmp/panama/" > gradle.properties
+        - echo "org.gradle.jvmargs=--add-modules jdk.incubator.foreign" >> gradle.properties
       install:
         - ./gradlew core:assemble -x core:test
       script:
         - ./gradlew core:build -x core:test
+    - stage: release
+      before_install:
+        - wget -O panama.zip https://coconucos.cs.hhu.de/forschung/jdk/latest.zip
+        - unzip panama.zip -d /tmp
+        - echo "org.gradle.java.installations.paths=/tmp/panama/" > gradle.properties
+        - echo "org.gradle.jvmargs=--add-modules jdk.incubator.foreign" >> gradle.properties
+      install:
+        - ./gradlew core:assemble -x core:test
+      script:
+        - ./gradlew publish -Dgpr.user=${GPR_USER} -Dgpr.token=${GPR_TOKEN} -Drelease=true
+        - export PUBLISH=true
+
+deploy:
+  provider: releases
+  token: ${ACCESS_TOKEN}
+  overwrite: true
+  on:
+    repo: hhu-bsinfo/infinileap
+    branch: master
+    tags: true
+    condition: ${PUBLISH} = true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+os: linux
+dist: focal
+language: java
+
+addons:
+  apt:
+    sources:
+      - sourceline: deb http://coconucos.cs.uni-duesseldorf.de/forschung/apt/ stable main
+        key_url: http://coconucos.cs.uni-duesseldorf.de/forschung/apt/apt-key.asc
+    packages:
+      - libllvm11
+      - ucx
+
+stages:
+  - name: build
+
+jobs:
+  include:
+    - stage: build
+      before_install:
+        - wget -O panama.zip https://coconucos.cs.hhu.de/forschung/jdk/latest.zip
+        - unzip panama.zip -d /tmp
+        - echo "org.gradle.java.installations.paths=/tmp/panama/" > gradle.properties
+      install:
+        - ./gradlew core:assemble -x core:test
+      script:
+        - ./gradlew core:build -x core:test

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 </p>
 
 <p align="center">
+  <a href="https://travis-ci.com/github/hhu-bsinfo/infinileap"><img src="https://www.travis-ci.com/hhu-bsinfo/infinileap.svg?branch=main"></a>
   <a href="https://openjdk.java.net/projects/jdk/19/"><img src="https://img.shields.io/badge/java-19-blue.svg"></a>
-<a href="https://github.com/openucx/ucx/tree/v1.11.2"><img src="https://img.shields.io/badge/ucx-1.11.2-red.svg"></a>
+  <a href="https://github.com/openucx/ucx/tree/v1.11.2"><img src="https://img.shields.io/badge/ucx-1.11.2-red.svg"></a>
   <a href="https://github.com/hhu-bsinfo/infinileap/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-orange.svg"></a>
   
 </p>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <a href="https://openjdk.java.net/projects/jdk/18/"><img src="https://img.shields.io/badge/java-18-blue.svg"></a>
+  <a href="https://openjdk.java.net/projects/jdk/19/"><img src="https://img.shields.io/badge/java-19-blue.svg"></a>
 <a href="https://github.com/openucx/ucx/tree/v1.11.2"><img src="https://img.shields.io/badge/ucx-1.11.2-red.svg"></a>
   <a href="https://github.com/hhu-bsinfo/infinileap/blob/master/LICENSE"><img src="https://img.shields.io/badge/license-GPLv3-orange.svg"></a>
   
@@ -115,7 +115,7 @@ This demo atomically increments a value residing inside the remote server's memo
   - If your JDK is not installed in one of the default locations, Gradle can be instructed to look in a custom location. To enable this feature the `org.gradle.java.installations.paths` property has to be set within your global `gradle.properties` file usually located inside `${HOME}/.gradle`.
     
     ```
-    org.gradle.java.installations.paths=/custom/path/jdk18
+    org.gradle.java.installations.paths=/custom/path/jdk19
     ```
     
   - The HotSpot VM uses the SIGSEGV signal for its own purposes, which may interfere with signal handlers installed by the ucx library. Fortunately, ucx's signal handlers can be disabled by using an undocumented environment variable (see [MPI.jl issue #337](https://github.com/JuliaParallel/MPI.jl/issues/337#issuecomment-578377458)).
@@ -135,7 +135,7 @@ This demo atomically increments a value residing inside the remote server's memo
 
 ## :wrench: &nbsp; Requirements
 
-  * [OpenJDK 18 + Project Panama](https://github.com/openjdk/panama-foreign/tree/foreign-jextract)
+  * [OpenJDK 19 + Project Panama](https://github.com/openjdk/panama-foreign/tree/foreign-jextract)
       
     > We provide nightly builds of the `foreign-jextract` branch, which are compatible with [SDKMAN!](https://sdkman.io).
     > 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ ext {
     protobufVersion = '3.15.8'
 
     // Logging
-    slf4jVersion = '1.7.30'
+    slf4jVersion = '1.7.32'
     log4jVersion = '2.14.1'
 
     // Benchmarking
@@ -18,11 +18,11 @@ ext {
     // Code Generation
     lombokVersion = '1.18.20'
     tomcatAnnotationsVersion = '6.0.53'
-    jetbrainsAnnotationsVersion = '20.1.0'
+    jetbrainsAnnotationsVersion = '22.0.0'
 
     // Testing
-    junitJupiterVersion = '5.7.1'
-    assertjVersion = '3.19.0'
+    junitJupiterVersion = '5.8.2'
+    assertjVersion = '3.21.0'
 }
 
 buildscript {
@@ -38,5 +38,5 @@ subprojects {
 }
 
 wrapper {
-    gradleVersion = "7.2"
+    gradleVersion = "7.3.1"
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'idea'
     id 'java-library'
+    id 'maven-publish'
     id "io.github.krakowski.jextract" version "0.2.2"
 }
 
@@ -15,6 +16,22 @@ version = getProperty('projectVersion')
 
 tasks.withType(Javadoc) {
     failOnError false
+}
+
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    archiveClassifier.set('javadoc')
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
 }
 
 dependencies {
@@ -302,3 +319,5 @@ jextract {
         ]
     }
 }
+
+apply from: 'publish.gradle'

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(18))
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }
 

--- a/core/publish.gradle
+++ b/core/publish.gradle
@@ -1,0 +1,60 @@
+def pomConfig = {
+    licenses {
+        license {
+            name 'GNU General Public License, Version 3.0'
+            url 'https://www.gnu.org/licenses/gpl-3.0.txt'
+            distribution "repo"
+        }
+    }
+
+    developers {
+        developer {
+            id 'krakowski'
+            name 'Filip Krakowski'
+            email 'krakowski@hhu.de'
+        }
+    }
+
+    scm {
+        url 'https://github.com/hhu-bsinfo/infinileap'
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/hhu-bsinfo/infinileap")
+            credentials {
+                username = System.getProperty('gpr.user')
+                password = System.getProperty('gpr.token')
+            }
+        }
+    }
+    publications {
+        gpr(MavenPublication) {
+            artifact jar {
+            }
+
+            artifact sourcesJar {
+                classifier 'sources'
+            }
+
+            artifact javadocJar {
+                classifier 'javadoc'
+            }
+
+            groupId project.group
+            artifactId 'infinileap'
+            version project.version
+
+            pom.withXml {
+                def root = asNode()
+                root.appendNode('description', 'A modern networking framework based on UCX for Java 19+')
+                root.appendNode('name', 'infinileap')
+                root.appendNode('url', 'https://github.com/hhu-bsinfo/infinileap')
+                root.children().last() + pomConfig
+            }
+        }
+    }
+}

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Context.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Context.java
@@ -138,7 +138,7 @@ public class Context extends NativeObject implements AutoCloseable {
             }
 
 
-            var remoteKey = MemorySegment.ofAddressNative(
+            var remoteKey = MemorySegment.ofAddress(
                     pointer.get(ValueLayout.ADDRESS, 0L),
                     size.get(ValueLayout.JAVA_LONG, 0L),
                     ResourceScope.globalScope()

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/util/MemoryUtil.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/util/MemoryUtil.java
@@ -16,7 +16,7 @@ public class MemoryUtil {
 
 
     public static MemorySegment wrap(MemoryAddress address, long capacity) {
-        return MemorySegment.ofAddressNative(address, capacity, ResourceScope.globalScope());
+        return MemorySegment.ofAddress(address, capacity, ResourceScope.globalScope());
     }
 
     public static MemorySegment allocate(MemoryLayout layout) {

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/util/NativeError.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/util/NativeError.java
@@ -7,7 +7,7 @@ import static org.unix.Linux.*;
 
 public class NativeError {
 
-    private static final MemorySegment ERRNO = MemorySegment.ofAddressNative(
+    private static final MemorySegment ERRNO = MemorySegment.ofAddress(
             __errno_location(), ValueLayout.ADDRESS.byteSize(), ResourceScope.globalScope());
 
     public static final int OK = 0;

--- a/daemon/build.gradle
+++ b/daemon/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(18))
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(18))
+        languageVersion.set(JavaLanguageVersion.of(19))
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR updates the build files to support publishing artifacts to the GitHub Package Registry.
Additionally, tags are automatically released via GitHub Releases and published to the GitHub Package Registry using Travis CI.

**CAUTION:** It is based on #4 