### PR TITLE
Throw CloseException instead of general Exception in MemoryRegion

### DIFF
--- a/core/src/main/java/de/hhu/bsinfo/infinileap/binding/MemoryRegion.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/binding/MemoryRegion.java
@@ -48,7 +48,7 @@ public class MemoryRegion implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void close() throws CloseException {
         var status = ucp_mem_unmap(context.address(), handle.address());
         if (Status.isNot(status, Status.OK)) {
             throw new CloseException(new ControlException(status));


### PR DESCRIPTION
Throwing the general Exception leads to more complicated error handling in methods that use the MemoryRegion class.