### PR TITLE
Worker: Fix tag mask being the same as tag

### DIFF
--- a/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Worker.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Worker.java
@@ -13,6 +13,7 @@ import static org.openucx.Communication.ucp_tag_recv_nbx;
 public class Worker extends NativeObject implements Watchable, AutoCloseable {
 
     private static final int NO_PROGRESS = 0;
+    private static final Tag TAG_MASK_FULL = Tag.of(0xffffffffffffffffL);
 
     private final Context context;
 
@@ -93,28 +94,44 @@ public class Worker extends NativeObject implements Watchable, AutoCloseable {
     }
 
     public long receiveTagged(NativeObject object, Tag tag) {
-        return receiveTagged(object.address(), object.byteSize(), tag, RequestParameters.EMPTY);
+        return receiveTagged(object.address(), object.byteSize(), tag, TAG_MASK_FULL, RequestParameters.EMPTY);
     }
 
     public long receiveTagged(NativeObject object, Tag tag, RequestParameters parameters) {
-        return receiveTagged(object.address(), object.byteSize(), tag, parameters);
+        return receiveTagged(object.address(), object.byteSize(), tag, TAG_MASK_FULL, parameters);
+    }
+
+    public long receiveTagged(NativeObject object, Tag tag, Tag tagMask) {
+        return receiveTagged(object.address(), object.byteSize(), tag, tagMask, RequestParameters.EMPTY);
+    }
+
+    public long receiveTagged(NativeObject object, Tag tag, Tag tagMask, RequestParameters parameters) {
+        return receiveTagged(object.address(), object.byteSize(), tag, tagMask, parameters);
     }
 
     public long receiveTagged(MemorySegment buffer, Tag tag) {
-        return receiveTagged(buffer, tag, RequestParameters.EMPTY);
+        return receiveTagged(buffer, tag, TAG_MASK_FULL, RequestParameters.EMPTY);
     }
 
     public long receiveTagged(MemorySegment buffer, Tag tag, RequestParameters parameters) {
-        return receiveTagged(buffer.address(), buffer.byteSize(), tag, parameters);
+        return receiveTagged(buffer, tag, TAG_MASK_FULL, parameters);
     }
 
-    private long receiveTagged(MemoryAddress address, long byteSize, Tag tag, RequestParameters parameters) {
+    public long receiveTagged(MemorySegment buffer, Tag tag, Tag tagMask) {
+        return receiveTagged(buffer, tag, tagMask, RequestParameters.EMPTY);
+    }
+
+    public long receiveTagged(MemorySegment buffer, Tag tag, Tag tagMask, RequestParameters parameters) {
+        return receiveTagged(buffer.address(), buffer.byteSize(), tag, tagMask, parameters);
+    }
+
+    private long receiveTagged(MemoryAddress address, long byteSize, Tag tag, Tag tagMask, RequestParameters parameters) {
         return ucp_tag_recv_nbx(
                 Parameter.of(this),
                 address,
                 byteSize,
                 tag.getValue(),
-                tag.getValue(),
+                tagMask.getValue(),
                 Parameter.of(parameters)
         );
     }


### PR DESCRIPTION
When receiving a tagged message, the tag mask indicates which bits of the tag shall be used for tag matching.
Currently, infinileap sets the tag mask to the same value as the tag, which causes some parts of the tag to be ignored.

This pull request implements the following changes to the `Worker` class:
- Set the default value for tag mask to `0xffffffffffffffff` (all bits set to 1)
- Add variants of `receiveTagged()`, that take a `tagMask` parameter