### PR TITLE
NativeInetSocketAddress: Implement wrap() and toInetSocketAddress(); …

### DIFF
--- a/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Listener.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Listener.java
@@ -1,11 +1,18 @@
 package de.hhu.bsinfo.infinileap.binding;
 
+import de.hhu.bsinfo.infinileap.common.network.NativeInetSocketAddress;
+import de.hhu.bsinfo.infinileap.common.util.BitMask;
 import de.hhu.bsinfo.infinileap.common.util.NativeObject;
-import java.lang.foreign.MemoryAddress;
-import java.lang.foreign.ValueLayout;
+import de.hhu.bsinfo.infinileap.common.util.flag.LongFlag;
+import org.openucx.ucp_listener_attr_t;
 
-import static org.openucx.OpenUcx.ucp_listener_destroy;
-import static org.openucx.OpenUcx.ucp_listener_reject;
+import java.lang.foreign.MemoryAddress;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.MemorySession;
+import java.lang.foreign.ValueLayout;
+import java.net.InetSocketAddress;
+
+import static org.openucx.OpenUcx.*;
 
 public class Listener extends NativeObject implements AutoCloseable {
 
@@ -27,8 +34,47 @@ public class Listener extends NativeObject implements AutoCloseable {
         }
     }
 
+    public InetSocketAddress getAddress() throws ControlException {
+        // Extract client address and address family from attributes
+        var attributes = queryAttributes(Field.SOCKADDR);
+        var listenerAddress = ucp_listener_attr_t.sockaddr$slice(attributes);
+
+        // Convert native address struct to InetSocketAddress
+        var nativeAddress = NativeInetSocketAddress.wrap(listenerAddress);
+        return nativeAddress.toInetSocketAddress();
+    }
+
     @Override
     public void close() {
         ucp_listener_destroy(address());
+    }
+
+    private MemorySegment queryAttributes(final Field... fields) throws ControlException {
+        // Allocate attributes struct and set requested fields
+        var listener_attr = ucp_listener_attr_t.allocate(MemorySession.openImplicit());
+        ucp_listener_attr_t.field_mask$set(listener_attr, BitMask.longOf(fields));
+
+        // Query requested fields
+        var status = ucp_listener_query(address(), listener_attr);
+        if (Status.isNot(status, Status.OK)) {
+            throw new ControlException(status);
+        }
+
+        return listener_attr;
+    }
+
+    public enum Field implements LongFlag {
+        SOCKADDR(UCP_LISTENER_ATTR_FIELD_SOCKADDR());
+
+        private final long value;
+
+        Field(int value) {
+            this.value = value;
+        }
+
+        @Override
+        public long getValue() {
+            return value;
+        }
     }
 }


### PR DESCRIPTION
This PR implements the methods `queryAttributes()` and `getAddress()` in `Listener`, similar to how it is done in `ConnectionRequest`.
To simplify the process of converting a native socket address to a Java `InetSocketAddress`, I implemented the methods `wrap()` and `toInetSocketAddress()` in `NativeSocketAddress`