### PR TITLE
Add methods to query local and remote address from endpoint

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -87,10 +87,12 @@ jextract {
                 'ucp_am_data_release', 'ucp_am_recv_data_nbx', 'ucp_am_send_nbx',
 
                 // Endpoint
-                'ucp_ep_close_nbx', 'ucp_ep_create', 'ucp_ep_destroy', 'ucp_ep_flush_nbx', 'ucp_ep_print_info', 'ucp_ep_rkey_unpack',
+                'ucp_ep_close_nbx', 'ucp_ep_create', 'ucp_ep_destroy', 'ucp_ep_flush_nbx', 'ucp_ep_print_info',
+                'ucp_ep_query', 'ucp_ep_rkey_unpack',
 
                 // Listener
-                'ucp_listener_create', 'ucp_listener_destroy', 'ucp_listener_query', 'ucp_listener_reject', 'ucp_conn_request_query',
+                'ucp_listener_create', 'ucp_listener_destroy', 'ucp_listener_query', 'ucp_listener_reject',
+                'ucp_conn_request_query',
 
                 // Memory
                 'ucp_mem_map', 'ucp_mem_print_info', 'ucp_mem_query', 'ucp_mem_unmap', 'ucp_mem_advise',
@@ -148,7 +150,8 @@ jextract {
                 // Worker
                 'ucp_worker_address_flags', 'ucp_worker_attr', 'ucp_worker_params',
 
-                'ucp_ep_params', 'ucp_err_handler', 'ucp_listener_conn_handler', 'ucp_mem_attr', 'ucp_am_recv_param',
+                'ucp_ep_params', 'ucp_ep_attr', 'ucp_err_handler', 'ucp_listener_conn_handler', 'ucp_mem_attr',
+                'ucp_am_recv_param',
 
                 // Socket
                 'ucs_sock_addr'
@@ -185,13 +188,13 @@ jextract {
 
                 'ucp_address_t', 'ucp_am_callback_t', 'ucp_am_recv_callback_t', 'ucp_am_recv_data_nbx_callback_t',
                 'ucp_am_recv_param_t', 'ucp_config_t', 'ucp_conn_request_h', 'ucp_context_h', 'ucp_datatype_t',
-                'ucp_ep_h', 'ucp_ep_params_t', 'ucp_err_handler_cb_t', 'ucp_err_handler_t', 'ucp_err_handling_mode_t',
-                'ucp_listener_accept_callback_t', 'ucp_listener_conn_callback_t', 'ucp_listener_conn_handler_t',
-                'ucp_listener_h', 'ucp_mem_attr_t', 'ucp_mem_h', 'ucp_request_cleanup_callback_t',
-                'ucp_request_init_callback_t', 'ucp_rkey_h', 'ucp_send_callback_t', 'ucp_send_nbx_callback_t',
-                'ucp_stream_recv_callback_t', 'ucp_stream_recv_nbx_callback_t', 'ucp_tag_message_h',
-                'ucp_tag_recv_callback_t', 'ucp_tag_recv_info_t', 'ucp_tag_recv_nbx_callback_t', 'ucp_tag_t',
-                'ucp_wakeup_event_t', 'ucp_worker_h',
+                'ucp_ep_h', 'ucp_ep_params_t', 'ucp_ep_attr_t', 'ucp_err_handler_cb_t', 'ucp_err_handler_t',
+                'ucp_err_handling_mode_t', 'ucp_listener_accept_callback_t', 'ucp_listener_conn_callback_t',
+                'ucp_listener_conn_handler_t', 'ucp_listener_h', 'ucp_mem_attr_t', 'ucp_mem_h',
+                'ucp_request_cleanup_callback_t', 'ucp_request_init_callback_t', 'ucp_rkey_h', 'ucp_send_callback_t',
+                'ucp_send_nbx_callback_t', 'ucp_stream_recv_callback_t', 'ucp_stream_recv_nbx_callback_t',
+                'ucp_tag_message_h', 'ucp_tag_recv_callback_t', 'ucp_tag_recv_info_t', 'ucp_tag_recv_nbx_callback_t',
+                'ucp_tag_t', 'ucp_wakeup_event_t', 'ucp_worker_h',
 
                 // Logging
                 'ucs_log_func_t', 'ucs_log_func_rc_t',
@@ -220,8 +223,9 @@ jextract {
                 'UCP_EP_PARAMS_FLAGS_CLIENT_SERVER', 'UCP_EP_PARAMS_FLAGS_NO_LOOPBACK',
                 'UCP_EP_PARAMS_FLAGS_SEND_CLIENT_ID', 'UCP_EP_PARAM_FIELD_CONN_REQUEST', 'UCP_EP_PARAM_FIELD_ERR_HANDLER',
                 'UCP_EP_PARAM_FIELD_ERR_HANDLING_MODE', 'UCP_EP_PARAM_FIELD_FLAGS', 'UCP_EP_PARAM_FIELD_REMOTE_ADDRESS',
-                'UCP_EP_PARAM_FIELD_SOCK_ADDR', 'UCP_EP_PARAM_FIELD_USER_DATA', 'UCP_FEATURE_AM', 'UCP_FEATURE_AMO32',
-                'UCP_FEATURE_AMO64', 'UCP_FEATURE_RMA', 'UCP_FEATURE_STREAM', 'UCP_FEATURE_TAG', 'UCP_FEATURE_WAKEUP',
+                'UCP_EP_PARAM_FIELD_SOCK_ADDR', 'UCP_EP_PARAM_FIELD_USER_DATA', 'UCP_EP_ATTR_FIELD_LOCAL_SOCKADDR',
+                'UCP_EP_ATTR_FIELD_REMOTE_SOCKADDR', 'UCP_FEATURE_AM', 'UCP_FEATURE_AMO32', 'UCP_FEATURE_AMO64',
+                'UCP_FEATURE_RMA', 'UCP_FEATURE_STREAM', 'UCP_FEATURE_TAG', 'UCP_FEATURE_WAKEUP',
                 'UCP_LISTENER_ATTR_FIELD_SOCKADDR', 'UCP_LISTENER_PARAM_FIELD_ACCEPT_HANDLER',
                 'UCP_LISTENER_PARAM_FIELD_CONN_HANDLER', 'UCP_LISTENER_PARAM_FIELD_SOCK_ADDR', 'UCP_MADV_NORMAL',
                 'UCP_MADV_WILLNEED', 'UCP_MEM_ADVISE_PARAM_FIELD_ADDRESS', 'UCP_MEM_ADVISE_PARAM_FIELD_ADVICE',

--- a/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Listener.java
+++ b/core/src/main/java/de/hhu/bsinfo/infinileap/binding/Listener.java
@@ -63,7 +63,7 @@ public class Listener extends NativeObject implements AutoCloseable {
         return listener_attr;
     }
 
-    public enum Field implements LongFlag {
+    private enum Field implements LongFlag {
         SOCKADDR(UCP_LISTENER_ATTR_FIELD_SOCKADDR());
 
         private final long value;


### PR DESCRIPTION
This PR adds the methods `Endpoint.getLocalAddress()` and `Endpoint.getRemoteAddress()`. The addresses are obtained using `ucp_ep_query()`, similar to how `Listener.getAddress()` is implemented.